### PR TITLE
[joss] Use ABC and abstractmethod rather than NotImplementedError

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: diart
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.8
+  - portaudio=19.6.*
+  - pysoundfile=0.12.*
+  - ffmpeg[version='<4.4']
+  - pip
+  - pip:
+    - .

--- a/src/diart/blocks/aggregation.py
+++ b/src/diart/blocks/aggregation.py
@@ -1,11 +1,12 @@
 from typing import Optional, List
+from abc import ABC, abstractmethod
 
 import numpy as np
 from pyannote.core import Segment, SlidingWindow, SlidingWindowFeature
 from typing_extensions import Literal
 
 
-class AggregationStrategy:
+class AggregationStrategy(ABC):
     """Abstract class representing a strategy to aggregate overlapping buffers
 
     Parameters
@@ -58,8 +59,9 @@ class AggregationStrategy:
         )
         return SlidingWindowFeature(aggregation, resolution)
 
+    @abstractmethod
     def aggregate(self, buffers: List[SlidingWindowFeature], focus: Segment) -> np.ndarray:
-        raise NotImplementedError
+        pass
 
 
 class HammingWeightedAverageStrategy(AggregationStrategy):

--- a/src/diart/blocks/config.py
+++ b/src/diart/blocks/config.py
@@ -1,4 +1,5 @@
 from typing import Any, Optional, Union, Tuple
+from abc import ABC, abstractmethod
 
 import numpy as np
 import torch
@@ -11,24 +12,29 @@ from ..audio import FilePath, AudioLoader
 
 class BasePipelineConfig:
     @property
+    @abstractmethod
     def duration(self) -> float:
-        raise NotImplementedError
+        pass
 
     @property
+    @abstractmethod
     def step(self) -> float:
-        raise NotImplementedError
+        pass
 
     @property
+    @abstractmethod
     def latency(self) -> float:
-        raise NotImplementedError
+        pass
 
     @property
+    @abstractmethod
     def sample_rate(self) -> int:
-        raise NotImplementedError
+        pass
 
     @staticmethod
+    @abstractmethod
     def from_dict(data: Any) -> 'BasePipelineConfig':
-        raise NotImplementedError
+        pass
 
     def get_file_padding(self, filepath: FilePath) -> Tuple[float, float]:
         file_duration = AudioLoader(self.sample_rate, mono=True).get_duration(filepath)

--- a/src/diart/blocks/diarization.py
+++ b/src/diart/blocks/diarization.py
@@ -1,4 +1,5 @@
 from typing import Optional, Tuple, Sequence
+from abc import ABC, abstractmethod
 
 import numpy as np
 import torch
@@ -12,26 +13,31 @@ from .utils import Binarize
 from .config import BasePipelineConfig, PipelineConfig
 
 
-class BasePipeline:
+class BasePipeline(ABC):
     @staticmethod
+    @abstractmethod
     def get_config_class() -> type:
-        raise NotImplementedError
+        pass
 
     @property
+    @abstractmethod
     def config(self) -> BasePipelineConfig:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def reset(self):
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def set_timestamp_shift(self, shift: float):
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def __call__(
         self,
         waveforms: Sequence[SlidingWindowFeature]
     ) -> Sequence[Tuple[Annotation, SlidingWindowFeature]]:
-        raise NotImplementedError
+        pass
 
 
 class OnlineSpeakerDiarization(BasePipeline):

--- a/src/diart/features.py
+++ b/src/diart/features.py
@@ -1,4 +1,5 @@
 from typing import Union, Optional
+from abc import ABC, abstractmethod
 
 import numpy as np
 import torch
@@ -7,15 +8,18 @@ from pyannote.core import SlidingWindow, SlidingWindowFeature
 TemporalFeatures = Union[SlidingWindowFeature, np.ndarray, torch.Tensor]
 
 
-class TemporalFeatureFormatterState:
+class TemporalFeatureFormatterState(ABC):
     """
     Represents the recorded type of a temporal feature formatter.
     Its job is to transform temporal features into tensors and
     recover the original format on other features.
     """
-    def to_tensor(self, features: TemporalFeatures) -> torch.Tensor:
-        raise NotImplementedError
 
+    @abstractmethod
+    def to_tensor(self, features: TemporalFeatures) -> torch.Tensor:
+        pass
+
+    @abstractmethod
     def to_internal_type(self, features: torch.Tensor) -> TemporalFeatures:
         """
         Cast `features` to the representing type and remove batch dimension if required.
@@ -28,7 +32,7 @@ class TemporalFeatureFormatterState:
         -------
         new_features: SlidingWindowFeature or numpy.ndarray or torch.Tensor, shape (batch, frames, dim)
         """
-        raise NotImplementedError
+        pass
 
 
 class SlidingWindowFeatureFormatterState(TemporalFeatureFormatterState):

--- a/src/diart/mapping.py
+++ b/src/diart/mapping.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Callable, Iterable, List, Optional, Text, Tuple, Union, Dict
+from abc import ABC, abstractmethod
 
 import numpy as np
 from pyannote.core.utils.distance import cdist
@@ -51,16 +52,19 @@ class MappingMatrixObjective:
         return -1e10 if self.maximize else 1e10
 
     @property
+    @abstractmethod
     def maximize(self) -> bool:
-        raise NotImplementedError()
+        pass
 
     @property
+    @abstractmethod
     def best_possible_value(self) -> float:
-        raise NotImplementedError()
+        pass
 
     @property
+    @abstractmethod
     def best_value_fn(self) -> Callable:
-        raise NotImplementedError()
+        pass
 
 
 class MinimizationObjective(MappingMatrixObjective):

--- a/src/diart/models.py
+++ b/src/diart/models.py
@@ -1,4 +1,5 @@
 from typing import Optional, Text, Union, Callable
+from abc import ABC, abstractmethod
 
 import torch
 import torch.nn as nn
@@ -20,7 +21,7 @@ class PyannoteLoader:
         return pyannote_loader.get_model(self.model_info, self.hf_token)
 
 
-class LazyModel(nn.Module):
+class LazyModel(nn.Module, ABC):
     def __init__(self, loader: Callable[[], nn.Module]):
         super().__init__()
         self.get_model = loader
@@ -69,13 +70,16 @@ class SegmentationModel(LazyModel):
         return PyannoteSegmentationModel(model, use_hf_token)
 
     @property
+    @abstractmethod
     def sample_rate(self) -> int:
-        raise NotImplementedError
+        pass
 
     @property
+    @abstractmethod
     def duration(self) -> float:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def forward(self, waveform: torch.Tensor) -> torch.Tensor:
         """
         Forward pass of the segmentation model.
@@ -88,7 +92,7 @@ class SegmentationModel(LazyModel):
         -------
         speaker_segmentation: torch.Tensor, shape (batch, frames, speakers)
         """
-        raise NotImplementedError
+        pass
 
 
 class PyannoteSegmentationModel(SegmentationModel):
@@ -132,6 +136,7 @@ class EmbeddingModel(LazyModel):
         assert _has_pyannote, "No pyannote.audio installation found"
         return PyannoteEmbeddingModel(model, use_hf_token)
 
+    @abstractmethod
     def forward(
         self,
         waveform: torch.Tensor,
@@ -150,7 +155,7 @@ class EmbeddingModel(LazyModel):
         -------
         speaker_embeddings: torch.Tensor, shape (batch, embedding_dim)
         """
-        raise NotImplementedError
+        pass
 
 
 class PyannoteEmbeddingModel(EmbeddingModel):

--- a/src/diart/progress.py
+++ b/src/diart/progress.py
@@ -1,36 +1,45 @@
 from typing import Optional, Text
 
+from abc import ABC, abstractmethod
 import rich
 from rich.progress import Progress, TaskID
 from tqdm import tqdm
 
 
-class ProgressBar:
+class ProgressBar(ABC):
+    @abstractmethod
     def create(self, total: int, description: Optional[Text] = None, unit: Text = "it", **kwargs):
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def start(self):
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def update(self, n: int = 1):
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def write(self, text: Text):
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def stop(self):
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def close(self):
-        raise NotImplementedError
+        pass
 
     @property
+    @abstractmethod
     def default_description(self) -> Text:
-        raise NotImplementedError
+        pass
 
     @property
+    @abstractmethod
     def initial_description(self) -> Optional[Text]:
-        raise NotImplementedError
+        pass
 
     def resolve_description(self, new_description: Optional[Text] = None) -> Text:
         if self.initial_description is None:

--- a/src/diart/sources.py
+++ b/src/diart/sources.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from queue import SimpleQueue
 from typing import Text, Optional, AnyStr, Dict, Any, Union, Tuple
+from abc import ABC, abstractmethod
 
 import numpy as np
 import sounddevice as sd
@@ -14,7 +15,7 @@ from websocket_server import WebsocketServer
 from .audio import FilePath, AudioLoader
 
 
-class AudioSource:
+class AudioSource(ABC):
     """Represents a source of audio that can start streaming via the `stream` property.
 
     Parameters
@@ -34,13 +35,15 @@ class AudioSource:
         """The duration of the stream if known. Defaults to None (unknown duration)."""
         return None
 
+    @abstractmethod
     def read(self):
         """Start reading the source and yielding samples through the stream."""
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def close(self):
         """Stop reading the source and close all open streams."""
-        raise NotImplementedError
+        pass
 
 
 class FileAudioSource(AudioSource):


### PR DESCRIPTION
`NotImplementedError` has slightly different semantics and effects than using `ABC` and `abstractmethod` - ABC classes can't be instantiated without satisfying all their abstractmethods, vs. raising an error which might not be obvious until the class is actually used. This also allows for static analysis tools to warn you when you haven't completed all the abstractmethods :)

part of: https://github.com/openjournals/joss-reviews/issues/5266