### PR TITLE
Add reproducibility warning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,8 @@ If you found diart useful, please make sure to cite our paper:
 
 ![Results table](https://github.com/juanmc2005/diart/blob/main/table1.png?raw=true)
 
+**We highly recommend to install pyannote.audio<3.1 to reproduce these results.**
+
 Diart aims to be lightweight and capable of real-time streaming in practical scenarios.
 Its performance is very close to what is reported in the paper (and sometimes even a bit better).
 

--- a/README.md
+++ b/README.md
@@ -377,7 +377,8 @@ If you found diart useful, please make sure to cite our paper:
 
 ![Results table](https://github.com/juanmc2005/diart/blob/main/table1.png?raw=true)
 
-**We highly recommend to install pyannote.audio<3.1 to reproduce these results.**
+**Important:** We highly recommend installing `pyannote.audio<3.1` to reproduce these results.
+For more information, see [this issue](https://github.com/juanmc2005/diart/issues/214).
 
 Diart aims to be lightweight and capable of real-time streaming in practical scenarios.
 Its performance is very close to what is reported in the paper (and sometimes even a bit better).

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [metadata]
 name=diart
-version=0.8.0
+version=0.9.0
 author=Juan Manuel Coria
-description=Streaming speaker diarization in real-time
+description=A python framework to build AI for real-time speech
 long_description=file: README.md
 long_description_content_type=text/markdown
 keywords=speaker diarization, streaming, online, real time, rxpy


### PR DESCRIPTION
### Changelog
- Bump up version to 0.9.0
- Add reproducibility note in README.md to warn about using `pyannote.audio<3.1`