### PR TITLE
Fix embedding extraction example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,9 @@ source = MicrophoneAudioSource()
 # To take input from file:
 # source = FileAudioSource("<filename>", sample_rate=16000)
 
+# Make sure the model has been trained with the same sample rate
+print(source.sample_rate)
+
 stream = mic.stream.pipe(
     # Reformat stream to 5s duration and 500ms shift
     dops.rearrange_audio_stream(sample_rate=source.sample_rate),

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ source = MicrophoneAudioSource()
 # To take input from file:
 # source = FileAudioSource("<filename>", sample_rate=16000)
 
-# Make sure the model has been trained with the same sample rate
+# Make sure the models have been trained with this sample rate
 print(source.sample_rate)
 
 stream = mic.stream.pipe(

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ mic = MicrophoneAudioSource()
 
 stream = mic.stream.pipe(
     # Reformat stream to 5s duration and 500ms shift
-    dops.rearrange_audio_stream(sample_rate=segmentation.model.sample_rate),
+    dops.rearrange_audio_stream(sample_rate=16000),
     ops.map(lambda wav: (wav, segmentation(wav))),
     ops.starmap(embedding)
 ).subscribe(on_next=lambda emb: print(emb)) #emb.shape to display shape

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Obtain overlap-aware speaker embeddings from a microphone stream:
 ```python
 import rx.operators as ops
 import diart.operators as dops
-from diart.sources import MicrophoneAudioSource #, FileAudioSource
+from diart.sources import MicrophoneAudioSource, FileAudioSource
 from diart.blocks import SpeakerSegmentation, OverlapAwareSpeakerEmbedding
 
 segmentation = SpeakerSegmentation.from_pretrained("pyannote/segmentation", use_hf_token="")

--- a/README.md
+++ b/README.md
@@ -287,33 +287,30 @@ import diart.operators as dops
 from diart.sources import MicrophoneAudioSource, FileAudioSource
 from diart.blocks import SpeakerSegmentation, OverlapAwareSpeakerEmbedding
 
-segmentation = SpeakerSegmentation.from_pretrained("pyannote/segmentation", use_hf_token="")
-embedding = OverlapAwareSpeakerEmbedding.from_pretrained("pyannote/embedding", use_hf_token="")
+segmentation = SpeakerSegmentation.from_pretrained("pyannote/segmentation")
+embedding = OverlapAwareSpeakerEmbedding.from_pretrained("pyannote/embedding")
 
-mic = MicrophoneAudioSource()
+source = MicrophoneAudioSource()
 # To take input from file:
-# mic = FileAudioSource("<filename>", sample_rate=16000)
+# source = FileAudioSource("<filename>", sample_rate=16000)
 
 stream = mic.stream.pipe(
     # Reformat stream to 5s duration and 500ms shift
-    dops.rearrange_audio_stream(sample_rate=16000),
+    dops.rearrange_audio_stream(sample_rate=source.sample_rate),
     ops.map(lambda wav: (wav, segmentation(wav))),
     ops.starmap(embedding)
-).subscribe(on_next=lambda emb: print(emb)) #emb.shape to display shape
+).subscribe(on_next=lambda emb: print(emb.shape))
 
-mic.read()
+source.read()
 ```
 
 Output:
 
 ```
-# Displaying embeds: 
-tensor([[[-0.0442, -0.0327, -0.0910,  ...,  0.0134,  0.0209,  0.0050],
-         [-0.0404, -0.0342, -0.0780,  ...,  0.0395,  0.0334, -0.0140],
-         [-0.0404, -0.0342, -0.0780,  ...,  0.0395,  0.0334, -0.0140]]])
-tensor([[[-0.0724,  0.0049, -0.0660,  ...,  0.0359,  0.0247, -0.0256],
-         [-0.0462, -0.0256, -0.0642,  ...,  0.0417,  0.0273, -0.0135],
-         [-0.0459, -0.0263, -0.0639,  ...,  0.0412,  0.0269, -0.0131]]])
+# Shape is (batch_size, num_speakers, embedding_dim)
+torch.Size([1, 3, 512])
+torch.Size([1, 3, 512])
+torch.Size([1, 3, 512])
 ...
 ```
 


### PR DESCRIPTION
Updated README embed-extraction pipeline example with new sample rate = 16000. Also updated the print to display the embeds and added hf_token parameter.

Let me know if you only want the new sample rate and i can create a new pull request.