### PR TITLE
fixed the torch audio detaching issue

### DIFF
--- a/src/diart/sources.py
+++ b/src/diart/sources.py
@@ -297,7 +297,7 @@ class TorchStreamAudioSource(AudioSource):
                 if self.is_closed:
                     break
                 # shape (samples, channels) to (1, samples)
-                chunk = np.mean(item[0].numpy(), axis=1, keepdims=True).T
+                chunk = np.mean(item[0].detach().numpy(), axis=1, keepdims=True).T
                 self.stream.on_next(chunk)
             except BaseException as e:
                 self.stream.on_error(e)


### PR DESCRIPTION
Hi @juanmc2005 ,

This PR is solving the error of complaining torch doesn't have subclass numpy issue. It's just detaching the torch before call numpy(). Please review and let me know your thoughts. BTW, Love your work on the on-line speaker diarization package.  Thanks.

Peng